### PR TITLE
test: make anchor tests idempotent

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,20 @@ Test all projects
 pnpm test
 ```
 
+To iterate on the `anchor` program using a local validator, this is the recommended workflow:
+
+Open this in one terminal:
+
+```shell
+pnpm anchor localnet
+```
+
+And this in another:
+
+```shell
+pnpm anchor test --skip-deploy --skip-local-validator
+```
+
 ## License
 
 MIT

--- a/anchor/tests/pubkey-protocol.spec.ts
+++ b/anchor/tests/pubkey-protocol.spec.ts
@@ -4,7 +4,13 @@ import { Keypair, LAMPORTS_PER_SOL, SystemProgram } from '@solana/web3.js'
 import { getPubKeyPointerPda, getPubKeyProfilePda, PubKeyIdentityProvider } from '../src'
 import { PubkeyProtocol } from '../target/types/pubkey_protocol'
 
+// Take a string str and return it with some unique digits appended
+function unique(str: string) {
+  return `${str}_${Math.random().toString(36).substring(2, 15)}`
+}
+
 describe('pubkey-protocol', () => {
+  const username = unique('alice')
   // Configure the client to use the local cluster.
   const provider = anchor.AnchorProvider.env()
   anchor.setProvider(provider)
@@ -24,8 +30,7 @@ describe('pubkey-protocol', () => {
 
   describe('Profile', () => {
     it('Create PubkeyProfile', async () => {
-      const username = 'alice'
-      const [profile, bump] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile, bump] = getPubKeyProfilePda({ username, programId: program.programId })
       const [pointer, bumpPointer] = getPubKeyPointerPda({
         programId: program.programId,
         provider: PubKeyIdentityProvider.Solana,
@@ -82,7 +87,7 @@ describe('pubkey-protocol', () => {
     })
 
     it('Update profile details', async () => {
-      const [profile] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile] = getPubKeyProfilePda({ username, programId: program.programId })
       const input = {
         authority: authority.publicKey,
         newName: 'Test Profile',
@@ -102,7 +107,7 @@ describe('pubkey-protocol', () => {
     })
 
     it('Add Authority', async () => {
-      const [profile] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile] = getPubKeyProfilePda({ username, programId: program.programId })
 
       await program.methods
         .addProfileAuthority({ newAuthority: authority2.publicKey })
@@ -124,7 +129,7 @@ describe('pubkey-protocol', () => {
     })
 
     it('Remove Authority', async () => {
-      const [profile] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile] = getPubKeyProfilePda({ username, programId: program.programId })
 
       await program.methods
         .removeAuthority({ authorityToRemove: authority2.publicKey })
@@ -138,16 +143,16 @@ describe('pubkey-protocol', () => {
     })
 
     it('Add Identity', async () => {
-      const [profile] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile] = getPubKeyProfilePda({ username, programId: program.programId })
       const [pointer, bump] = getPubKeyPointerPda({
         programId: program.programId,
-        providerId: 'alice-discord-id-123',
+        providerId: `${username}-discord-id-123`,
         provider: PubKeyIdentityProvider.Discord,
       })
       const input = {
-        providerId: 'alice-discord-id-123',
+        providerId: `${username}-discord-id-123`,
         provider: { discord: {} },
-        nickname: 'alice_discord',
+        nickname: `${username}_discord`,
       }
       await program.methods
         .addIdentity(input)
@@ -187,15 +192,15 @@ describe('pubkey-protocol', () => {
     })
 
     it('Remove Identity', async () => {
-      const [profile] = getPubKeyProfilePda({ username: 'alice', programId: program.programId })
+      const [profile] = getPubKeyProfilePda({ username, programId: program.programId })
       const [pointer] = getPubKeyPointerPda({
         programId: program.programId,
-        providerId: 'alice-discord-id-123',
+        providerId: `${username}-discord-id-123`,
         provider: PubKeyIdentityProvider.Discord,
       })
 
       await program.methods
-        .removeIdentity({ providerId: 'alice-discord-id-123' })
+        .removeIdentity({ providerId: `${username}-discord-id-123` })
         .accountsStrict({
           authority: authority.publicKey,
           feePayer: feePayer.publicKey,

--- a/anchor/tests/pubkey-protocol.spec.ts
+++ b/anchor/tests/pubkey-protocol.spec.ts
@@ -4,9 +4,12 @@ import { Keypair, LAMPORTS_PER_SOL, SystemProgram } from '@solana/web3.js'
 import { getPubKeyPointerPda, getPubKeyProfilePda, PubKeyIdentityProvider } from '../src'
 import { PubkeyProtocol } from '../target/types/pubkey_protocol'
 
-// Take a string str and return it with some unique digits appended
 function unique(str: string) {
   return `${str}_${Math.random().toString(36).substring(2, 15)}`
+}
+
+function getAvatarUrl(username: string) {
+  return `https://api.dicebear.com/9.x/bottts-neutral/svg?seed=${username}`
 }
 
 describe('pubkey-protocol', () => {
@@ -39,7 +42,7 @@ describe('pubkey-protocol', () => {
 
       await program.methods
         .createProfile({
-          avatarUrl: 'https://avatars.githubusercontent.com/u/32637757?v=4',
+          avatarUrl: getAvatarUrl(username),
           name: 'Test Profile',
           username,
         })
@@ -69,7 +72,7 @@ describe('pubkey-protocol', () => {
       expect(postBalance).toStrictEqual(LAMPORTS_PER_SOL)
       expect(receivedBump).toStrictEqual(bump)
       expect(receivedUsername).toStrictEqual(username)
-      expect(avatarUrl).toStrictEqual('https://avatars.githubusercontent.com/u/32637757?v=4')
+      expect(avatarUrl).toStrictEqual(getAvatarUrl(username))
       expect(authorities).toEqual([authority.publicKey])
       expect(receivedFeePayer).toStrictEqual(feePayer.publicKey)
 
@@ -91,7 +94,7 @@ describe('pubkey-protocol', () => {
       const input = {
         authority: authority.publicKey,
         newName: 'Test Profile',
-        newAvatarUrl: 'https://avatars.githubusercontent.com/u/36491?v=4',
+        newAvatarUrl: getAvatarUrl(`${username}_new`),
       }
       await program.methods
         .updateProfileDetails(input)
@@ -242,7 +245,7 @@ describe('pubkey-protocol', () => {
         .createCommunity({
           slug,
           name: 'Test Community',
-          avatarUrl: 'https://example.com/avatar.png',
+          avatarUrl: getAvatarUrl(slug),
           discord: 'https://discord.gg/testcommunity',
           github: 'https://github.com/testcommunity',
           website: 'https://testcommunity.com',
@@ -262,7 +265,7 @@ describe('pubkey-protocol', () => {
       console.log('communityAccount', communityAccount)
       expect(communityAccount.slug).toEqual(slug)
       expect(communityAccount.name).toEqual('Test Community')
-      expect(communityAccount.avatarUrl).toEqual('https://example.com/avatar.png')
+      expect(communityAccount.avatarUrl).toEqual(getAvatarUrl(slug))
       expect(communityAccount.x).toEqual('https://x.com/testcommunity')
       expect(communityAccount.discord).toEqual('https://discord.gg/testcommunity')
       expect(communityAccount.github).toEqual('https://github.com/testcommunity')


### PR DESCRIPTION
This makes sure we can run the `anchor` tests over and over again without having to restart the local validator.